### PR TITLE
Creating a new script creates a text script not a Python script

### DIFF
--- a/R/ecoretriever.r
+++ b/R/ecoretriever.r
@@ -67,7 +67,7 @@ data_ls = function(){
 #' 
 #' @param filename the name of the script to generate
 #' @export
-#' @examples new_script('newscript.py')
+#' @examples new_script('newscript.script')
 new_script = function(filename){
   system(paste('retriever new', filename)) 
 }

--- a/man/new_script.Rd
+++ b/man/new_script.Rd
@@ -11,6 +11,6 @@ new_script(filename)
 Create a new sample retriever script
 }
 \examples{
-new_script('newscript.py')
+new_script('newscript.script')
 }
 


### PR DESCRIPTION
Therefore the examples should the use of the .script extension
not the .py extension.
