### PR TITLE
Remove instructions for adding Retriever to the Windows path 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,39 +20,8 @@ or it can be installed from [source](https://github.com/weecology/retriever).
 Add Retriever to the path
 -------------------------
 The R package takes advantage of the EcoData Retriever's command line interface
-which must be enabled by adding it to the path on Windows and Mac platforms.
-
-###Windows Specific Instructions
-
-####Temporarily add retriever to path
-
-In an active R session the following commands will temporaily add the retriever to the path:
-
-```coffee
-## first check that retriever is not already on the path
-grepl('EcoDataRetriever', Sys.getenv('PATH'))
-#[1] FALSE
-## add to existing path
-newpath = paste(Sys.getenv('PATH'), 'C:\\Program Files\\EcoDataRetriever', sep=';')
-Sys.setenv('PATH' = newpath)
-```
-
-####Permanently add retriever to path
-
-How you set the path (aka environment variable) is system specific: 
-
-* Under Windows 2000/XP/2003 you can use 'System' in the control panel or the 
-properties of 'My Computer' (under the 'Advanced' tab). 
-
-* Under Vista and Windows 7, go to 'User Accounts' in the control panel, 
-and select your account and then 'Change my environment variables'
-
-Once you are in the change environment variable box, select "New". 
-Name the new variable "PATH" and then set the value to (at a minimum):
-
-```
-PATH=C:/Program Files/EcoDataRetriever;
-```
+which must be enabled by adding it to the path on Mac platforms.
+On a Windows platform the Retriever should be added automatically to the path.
 
 Install R package
 -----------------


### PR DESCRIPTION
On Windows platforms the Retriever is now automatically added to the path: https://github.com/weecology/retriever/commit/ac26b3e4b06b14097a3c732fb9c16769ae9426f1. Therefore the instructions for how to add the Retriever to the path were removed.
