### PR TITLE
During script update have the stdout printed to the screen

### DIFF
--- a/R/ecoretriever.R
+++ b/R/ecoretriever.R
@@ -147,6 +147,6 @@ datasets = function(){
     Use suppressPackageStartupMessages() to suppress these
     messages in the future")
   print('Please wait while retriever updates its scripts, ...')
-  system('retriever update', ignore.stdout=TRUE, ignore.stderr=TRUE)
-  print('Retriever script update complete!')
+  system('retriever update', ignore.stdout=FALSE, ignore.stderr=TRUE)
+  print('The retriever scripts are up-to-date!')
 }


### PR DESCRIPTION
The old code simply ignored the stdout which informs the user what scripts are being update. When the updates discussed in #23 are fully implemented by the retriever this will typically be a short list of file names or no file names at all if they are are up-to-date.
