### PR TITLE
Update download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-rdataretriever [![Build Status](https://cranlogs.r-pkg.org/badges/grand-total/ecoretriever)](https://cran.rstudio.com/web/packages/ecoretriever/index.html)
+rdataretriever [![Build Status](https://cranlogs.r-pkg.org/badges/grand-total/rdataretriever)](https://CRAN.R-project.org/package=rdataretriever)
 ============
 
 R interface to the [Data Retriever](http://data-retriever.org).


### PR DESCRIPTION
The package is now posted on CRAN #100 ... hooray! Let's update the download badge and then release a version 1.0.0 on github.