### PR TITLE
Issue 106 Fixes

### DIFF
--- a/R/rdataretriever.R
+++ b/R/rdataretriever.R
@@ -88,22 +88,39 @@ install = function(dataset, connection, db_file=NULL, conn_file=NULL,
 #' }
 fetch = function(dataset, quiet=TRUE){
   temp_path = tempdir()
-  if (quiet)
+  master = vector("list", length(dataset))
+  names(master) = dataset
+  z = 1
+  for (d in dataset) {
+  if (quiet){
     run_cli(paste('retriever -q install csv --table_name',
                  file.path(temp_path, '{db}_{table}.csv'),
-                 dataset))
-  else
-    install(dataset, connection='csv', data_dir=temp_path)
-  files = dir(temp_path)
-  dataset_underscores = gsub("-", "_", dataset) #retriever converts - in dataset name to _ in filename
-  files = files[grep(dataset_underscores, files)]
-  out = vector('list', length(files))
-  list_names = sub('.csv', '', files)
-  list_names = sub(paste(dataset, '_', sep=''), '', list_names)
-  names(out) = list_names
-  for (i in seq_along(files))
-    out[[i]] = utils::read.csv(file.path(temp_path, files[i]))
-  return(out)
+                 d))
+            }
+  else{
+    install(d, connection='csv', data_dir=temp_path)
+      }
+    files = dir(temp_path)
+    dataset_underscores = gsub("-", "_", d)
+    files = files[grep(dataset_underscores, files)]
+    out = vector("list", length(files))
+    list_names = sub(".csv", "", files)
+    list_names = sub(paste(dataset_underscores, "_", sep = ""), 
+                     "", list_names)
+    names(out) = list_names
+    for (i in seq_along(files)) {
+      out[[i]] = utils::read.csv(file.path(temp_path, 
+                                           files[i]))
+    }
+    master[[z]] <- out
+    z = z + 1
+  }
+  if (length(dataset) == 1) {
+    return(out) 
+  }
+  else {
+    return(master)
+  }
 }
 
 #' Download datasets via the Data Retriever.

--- a/R/rdataretriever.R
+++ b/R/rdataretriever.R
@@ -90,6 +90,7 @@ fetch = function(dataset, quiet=TRUE){
   temp_path = tempdir()
   master = vector("list", length(dataset))
   names(master) = dataset
+  names(master) = gsub("-","_",names(master))
   z = 1
   for (d in dataset) {
   if (quiet){

--- a/R/rdataretriever.R
+++ b/R/rdataretriever.R
@@ -74,8 +74,9 @@ install = function(dataset, connection, db_file=NULL, conn_file=NULL,
 #' Each datafile in a given dataset is downloaded to a temporary directory and
 #' then imported as a data.frame as a member of a named list.
 #'
-#' @param dataset the name of the dataset that you wish to download
+#' @param dataset the names of the dataset that you wish to download
 #' @param quiet logical, if true retriever runs in quiet mode
+#' @param dnames the names you wish to assign to the dataframes if downloading more than one dataset 
 #' @export
 #' @examples
 #' \donttest{
@@ -86,11 +87,22 @@ install = function(dataset, connection, db_file=NULL, conn_file=NULL,
 #' ## preview the data in the portal species datafile
 #' head(portal$species)
 #' }
-fetch = function(dataset, quiet=TRUE){
+fetch = function(dataset, quiet=TRUE, dnames=NULL){
   temp_path = tempdir()
   master = vector("list", length(dataset))
+  if (is.null(dnames)){
   names(master) = dataset
   names(master) = gsub("-","_",names(master))
+  }
+  else{
+    if (length(dnames)!=length(dataset)){
+      stop("Number of names must match number of datasets")
+    }
+    if ((length(dnames)==1)&(length(dataset)==1)){
+      stop("Assign name through the output instead. Example: yourname<-fetch('dataset')")
+    }
+    names(master) = dnames
+  }
   z = 1
   for (d in dataset) {
   if (quiet){


### PR DESCRIPTION
This pull addresses the issues discussed in issue #106.

There are currently inconsistencies in the naming of the data structures returned by `fetch()`. Datasets without hyphens in their name return the indexed data frames’ names without the original dataset name (`data<-fetch(‘portal’)` yields `data$main`) while datasets with hyphens in their name return data frames with the dataset name (`data<-fetch(‘mammal-community-db’)` yields `data$mammal_community_db_species` instead of `data$species`).

The proposed solution by @dmcglinn of deleting line 102 does not solve that issue. That line is important to the renaming structure as it removes the dataset name ‘header’ from non-hyphenated datasets (in the example above, without line 102, there would be `data$portal_main`). The reason it does not remove underscores from datasets like `mammal-community-db` is because it is attempting to search for the dataset name (which contains hyphens) in `list_names`, which has already converted the hyphens to underscores in line 98. Thus, it can’t find the hyphenated name within the underscored name and the underscores are not substituted.

A solution is changing line 102 to instead search using `dataset_underscores`. This now searches with the converted-to-underscore name in `list_names`. After the change, `fetch(‘portal’)` and `fetch(‘mammal-community-db’)` both yield lists that do not contain the dataset name.

In addition, I also implemented the suggestion by @ethanwhite to allow `fetch()` to accept multiple datasets and return them in a nested list. I do this by having the function create a `master` list and run a for loop for each dataset inputted, then store the output into a master list. Each dataset stored into the master list is stored under the original name of the dataset, but the master is what is returned and thus can be assigned to whatever name you want. Finally, in order to avoid unnecessary nesting, the function does not return the master dataset if the user only inputs one dataset and simply acts as it did before (although with the naming changes above).

In summary:
Old: `data<-fetch('portal')` yields `data$main`
New: `data<-fetch('portal')` yields `data$main`

Old: `data<-fetch(‘mammal-community-db’)` yields `data$mammal_community_db_species`
New: `data<-fetch(‘mammal-community-db’)` yields `data$species`

Old: `data<-fetch(c(‘mammal-community-db’,'portal))` yields `error`
New:  `data<-fetch(c(‘mammal-community-db’,'portal))` yields `data$portal$main` and `data$mammal_community_db$species`
