### PR TITLE
Create basic testing infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: r
+cache: packages
+sudo: false
+dist: trusty
+
+before_install:
+  - pip install --user retriever
+  - retriever update

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Depends:
     R (>= 3.0.0)
 Imports:
     utils
+Suggests: testthat
 SystemRequirements: Data Retriever (>= 1.8)
 License: MIT + file LICENSE
 LazyData: true

--- a/R/rdataretriever.R
+++ b/R/rdataretriever.R
@@ -176,7 +176,8 @@ datasets = function(){
 }
 
 #' Get dataset citation information and a description
-#' @return returns a character vector with the available datasets for download
+#' @param dataset name of the dataset
+#' @return returns a string with the citation information
 #' @export
 #' @examples 
 #' \donttest{

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 rdataretriever [![Build Status](https://cranlogs.r-pkg.org/badges/grand-total/rdataretriever)](https://CRAN.R-project.org/package=rdataretriever)
+[![Build Status](https://travis-ci.org/ropensci/rdataretriever.png)](https://travis-ci.org/ropensci/rdataretriever)
 ============
 
 R interface to the [Data Retriever](http://data-retriever.org).

--- a/man/get_citation.Rd
+++ b/man/get_citation.Rd
@@ -6,8 +6,11 @@
 \usage{
 get_citation(dataset)
 }
+\arguments{
+\item{dataset}{name of the dataset}
+}
 \value{
-returns a character vector with the available datasets for download
+returns a string with the citation information
 }
 \description{
 Get dataset citation information and a description

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(rdataretriever)
+
+test_check("rdataretriever")

--- a/tests/testthat/test-retriever.R
+++ b/tests/testthat/test-retriever.R
@@ -1,0 +1,7 @@
+library(testthat)
+library(rdataretriever)
+
+test_that("datasets returns some known values", {
+  skip_on_cran()
+  expect_identical("car-eval" %in% rdataretriever::datasets(), TRUE)
+})


### PR DESCRIPTION
Use Travis CI for automated testing. Installs the most recent release of the `retriever` from pypi so that the functions in the R package can then be tested.

Also fixes a documentation related warning to avoid failing based on the warning.