### PR TITLE
Switch to Python 3 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,15 @@ cache: packages
 sudo: false
 dist: trusty
 
+addons:
+  apt:
+    packages:
+      python3-pip
+
 before_install:
-  - pip install --user retriever
+  - pip3 install --user retriever
+  - echo y | retriever reset all
+  - retriever --version
   - retriever update
+  - retriever ls
+  - retriever ls


### PR DESCRIPTION
The builds are currently failing because of a bug in the Python 2 version that
causes issues downloading files over https.

Also, the retriever is faster on Python 3 speeding testing.