### PR TITLE
Add ORCIDs for authors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,15 +8,19 @@ Description: Provides an R interface to the Data Retriever
 Version: 1.0.0
 Date: 2017-02-21
 Authors@R: c(person("Daniel", "McGlinn", role = c("aut", "cre"),
-    email = "danmcglinn@gmail.com"),
+    email = "danmcglinn@gmail.com",
+    comment = c(ORCID = "0000-0003-2359-3526")),
     person("Henry", "Senyondo", role = "aut",
-    email = "henrykironde@gmail.com"),
+    email = "henrykironde@gmail.com",
+    comment = c(ORCID = "0000-0001-7105-5808")),
     person("Shawn", "Taylor", role = "aut",
-    email = "shawntaylor@weecology.org"),
+    email = "shawntaylor@weecology.org",
+    comment = c(ORCID = "0000-0002-6178-6903")),
     person("Max", "Pohlman", role = "aut",
     email = "maxpohlman@gmail.com"),
     person("Ethan", "White", role = "aut",
-    email = "ethan@weecology.org"))
+    email = "ethan@weecology.org",
+    comment = c(ORCID = "0000-0001-6728-7745")))
 BugReports: https://github.com/ropensci/rdataretriever/issues
 URL: https://github.com/ropensci/rdataretriever/
 Depends:


### PR DESCRIPTION
R now supports ORCIDs for author identification:
https://ropensci.org/technotes/2018/10/08/orcid/

Closes #119.