### PR TITLE
Reactivate MariaDB tests

### DIFF
--- a/tests/testthat/test-retriever.R
+++ b/tests/testthat/test-retriever.R
@@ -126,10 +126,10 @@ test_that("Install the dataset into Mysql", {
   portal <- c("main", "plots", "species")
   rdataretriever::install_mysql('portal', database_name = 'testdb_retriever',
     host = mysqldb_rdata)
-  # con <- dbConnect(RMariaDB::MariaDB(), default.file = mysql_conf)
-  # result <- dbListTables(con)
-  # dbDisconnect(con)
-  # expect_setequal(result, portal)
+    con <- dbConnect(RMariaDB::MariaDB(), default.file = mysql_conf)
+    result <- dbListTables(con)
+    dbDisconnect(con)
+    expect_setequal(result, portal)
 })
 
 


### PR DESCRIPTION
MariaDB was failing to connect using the connection file (#172).
I turned the tests back on in the hopes that this issue had been fixed upstream and everything now passes.

Closes #172.