### PR TITLE
Ensure all tests run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
 script:
   # Load packages and install the required packages
   # Install retriever from source and run tests
-  - docker-compose  run rdata /bin/sh -c 'Rscript load_and_test.R'
+  - docker-compose run -e NOT_CRAN=true rdata /bin/sh -c 'Rscript load_and_test.R'


### PR DESCRIPTION
skip_on_cran tests aren't currently running. This manually sets the
appropriate environmental variable to ensure they run.