### PR TITLE
Reactivate MariaDB tests for 1.0.0

### DIFF
--- a/tests/testthat/test-retriever_v1_0_0_backward.R
+++ b/tests/testthat/test-retriever_v1_0_0_backward.R
@@ -113,18 +113,18 @@ test_that("Install the dataset into Mysql", {
     ))
     portal <- c("main", "plots", "species")
     rdataretriever::install('portal', 'mysql')
-    ## RMariaDB api may need more tweaking
-    #   con <- dbConnect(
-    #     RMariaDB::MariaDB(),
-    #     user = 'travis',
-    #     host = mysqldb_rdata,
-    #     password = os_password,
-    #     port = 3306,
-    #     dbname = 'testdb_retriever'
-    #   )
-    #   result <- dbListTables(con)
-    #   dbDisconnect(con)
-    #   expect_setequal(result, portal)
+    # RMariaDB api may need more tweaking
+    con <- dbConnect(
+           RMariaDB::MariaDB(),
+           user = 'travis',
+           host = mysqldb_rdata,
+           password = os_password,
+           port = 3306,
+           dbname = 'testdb_retriever'
+          )
+    result <- dbListTables(con)
+    dbDisconnect(con)
+    expect_setequal(result, portal)
   }
 })
 


### PR DESCRIPTION
We reactivate the main tests in #219 but forgot to turn the backward compatibility tests back on.