### PR TITLE
Update retriever version parsing to use -dev

### DIFF
--- a/R/rdataretriever.R
+++ b/R/rdataretriever.R
@@ -153,8 +153,7 @@ get_script_upstream <- function(dataset, repo = "") {
 data_retriever_version <- function(clean = TRUE) {
   raw_version <- retriever$"__version__"
   if (clean) {
-    no_dev_version <- gsub(".dev", "", raw_version)
-    clean_version <- gsub("v", "", no_dev_version)
+    clean_version <- gsub("v", "", raw_version)
     return(clean_version)
   } else {
     return(raw_version)


### PR DESCRIPTION
retriever was updated to use the preffered -dev format instead of .dev.
This format is properly handled by semver::parse_version so we can keep
the dev indication now.