### PR TITLE
Avoid CRAN NOTE from checking retriever version

### DIFF
--- a/R/rdataretriever.R
+++ b/R/rdataretriever.R
@@ -769,6 +769,6 @@ retriever <- NULL
   ## assignment in parent environment!
   try({
     retriever <<- reticulate::import("retriever", delay_load = TRUE)
+    check_retriever_availability()
   }, silent = TRUE)
-  check_retriever_availability()
 }


### PR DESCRIPTION
I think this fixed everything based on:
https://cloud.r-project.org/web/checks/check_results_rdataretriever.html

Fixes #242