### PR TITLE
Disable check_retriever_availability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ RUN chmod 0644 ~/.Rprofile
 RUN chmod 0644 ~/.profile
 
 # Install retriever python package
+RUN pip install h5py
+RUN pip install pillow
+Run pip install kaggle
+# h5py, pillow, kaggle fail to install from the requirement file.
 RUN pip install git+https://git@github.com/weecology/retriever.git
 RUN retriever ls > /dev/null
 RUN pip install  psycopg2 pymysql > /dev/null

--- a/R/rdataretriever.R
+++ b/R/rdataretriever.R
@@ -769,6 +769,7 @@ retriever <- NULL
   ## assignment in parent environment!
   try({
     retriever <<- reticulate::import("retriever", delay_load = TRUE)
-    check_retriever_availability()
+    # dissable due to failure to test on win cran dev platform
+    # check_retriever_availability()
   }, silent = TRUE)
 }

--- a/R/rdataretriever.R
+++ b/R/rdataretriever.R
@@ -769,7 +769,7 @@ retriever <- NULL
   ## assignment in parent environment!
   try({
     retriever <<- reticulate::import("retriever", delay_load = TRUE)
-    # dissable due to failure to test on win cran dev platform
+    # Disable due to failure to test on win cran dev platform
     # check_retriever_availability()
   }, silent = TRUE)
 }


### PR DESCRIPTION
Window's cran test platform fails due to this functionality
To release v3.0, we are removing and providing it as
a function for users to run. This will be replaced later