### PR TITLE
Order affiliations by use

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -5,72 +5,69 @@ tags:
 authors:
  - name: Henry Senyondo
    orcid: 0000-0001-7105-5808
-   affiliation: 1, 4
+   affiliation: 1
  - name: Daniel J. McGlinn
    orcid: 0000-0003-2359-3526
-   affiliation: 6
+   affiliation: 2
  - name: Pranita Sharma
-   affiliation: 12
+   affiliation: 3
    orcid: 0000-0002-5871-380X
- - name: David J Harris
+ - name: David J. Harris
    affiliation: 1
    orcid: 0000-0003-3332-9307
  - name: Hao Ye
-   affiliation: 9
+   affiliation: 4
    orcid: 0000-0002-8630-1458
  - name: Shawn D. Taylor
-   affiliation: 1, 13
+   affiliation: 1, 5
    orcid: 0000-0002-6178-6903
  - name: Jeroen Ooms
-   affiliation: 10
+   affiliation: 6
    orcid: 0000-0002-4035-0289
  - name: Francisco Rodríguez-Sánchez
-   affiliation: 11
+   affiliation: 7
    orcid: 0000-0002-7981-1599
  - name: Karthik Ram
-   affiliation: 10
+   affiliation: 6
    orcid: 0000-0002-0233-1757
  - name: Apoorva Pandey
    affiliation: 8
    orcid: 0000-0001-9834-4415
  - name: Harshit Bansal
-   affiliation: 5
+   affiliation: 9
    orcid: 0000-0002-3285-812X
  - name: Max Pohlman
-   affiliation: 7
+   affiliation: 10
  - name: Ethan P. White
-   affiliation: 1, 2, 4
+   affiliation: 1, 11, 12
    orcid: 0000-0001-6728-7745
 
 
 affiliations:
  - name: Department of Wildlife Ecology and Conservation, University of Florida
    index: 1
- - name: Informatics Institute, University of Florida
-   index: 2
- - name: Delhi Technological University, Delhi
-   index: 3
- - name: The University of Florida
-   index: 4
- - name: Department of Electronics and Communication, Indian Institute of Technology, Roorkee
-   index: 5
  - name: Department of Biology, College of Charleston
+   index: 2
+ - name: North Carolina State University, Department of Computer Science
+   index: 3
+- name: Health Science Center Libraries, University of Florida
+   index: 4
+ - name: USDA-ARS Jornada Experimental Range
+   index: 5
+ - name: Berkeley Institute for Data Science, University of California, Berkeley
    index: 6
  - name: Department of Agricultural Economics, Sociology, and Education, Penn State University
    index: 7
- - name: Ajay Kumar Garg Engineering College, Ghaziabad
+ - name: Department of Electronics and Communication, Indian Institute of Technology, Roorkee
    index: 8
- - name: Health Science Center Libraries, University of Florida
+ - name: Ajay Kumar Garg Engineering College, Ghaziabad
    index: 9
- - name: Berkeley Institute for Data Science, University of California, Berkeley
-   index: 10
  - name: Departamento de Biología Vegetal y Ecología, Universidad de Sevilla. 
+   index: 10
+ - name: Informatics Institute, University of Florida
    index: 11
- - name: North Carolina State University, Department of Computer Science
+ - name: Biodiversity Institute, University of Florida
    index: 12
- - name: USDA-ARS Jornada Experimental Range
-   index: 13
-
 
 date: 16 September 2020 
 bibliography: paper.bib


### PR DESCRIPTION
This orders the affiliations to line up with the order of names in the author list. Delhi Technological University was removed because it didn't appear to be associated with anyone, but please check to ensure that is correct. Also please give this is careful check to make sure I didn't make any mistakes in the re-ordering since this is important to get precisely right.